### PR TITLE
#6: Transaction management

### DIFF
--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/exception/TransactionManagerException.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/exception/TransactionManagerException.java
@@ -1,0 +1,16 @@
+package com.bobocode.bibernate.exception;
+
+public class TransactionManagerException extends RuntimeException {
+
+  public TransactionManagerException(String message) {
+    super(message);
+  }
+
+  public TransactionManagerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TransactionManagerException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/session/Session.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/session/Session.java
@@ -1,5 +1,7 @@
 package com.bobocode.bibernate.session;
 
+import com.bobocode.bibernate.transaction.manager.TransactionManager;
+
 public interface Session {
 
   <T> T find(Class<T> entityClass, Object primaryKey);
@@ -11,4 +13,6 @@ public interface Session {
   void flush();
 
   void close();
+
+  TransactionManager getTransactionManager();
 }

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/session/impl/SimpleSession.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/session/impl/SimpleSession.java
@@ -2,7 +2,10 @@ package com.bobocode.bibernate.session.impl;
 
 import com.bobocode.bibernate.context.PersistenceContext;
 import com.bobocode.bibernate.session.Session;
+import com.bobocode.bibernate.transaction.ds.DelegatingDataSource;
+import com.bobocode.bibernate.transaction.manager.ThreadLocalTransactionManager;
 import javax.sql.DataSource;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -11,9 +14,13 @@ public class SimpleSession implements Session {
   private final PersistenceContext context;
   private final JDBCRepository jdbcRepository;
 
+  @Getter private final ThreadLocalTransactionManager transactionManager;
+
   public SimpleSession(DataSource dataSource) {
     this.context = new PersistenceContext();
-    this.jdbcRepository = new JDBCRepository(dataSource, context);
+    this.transactionManager = new ThreadLocalTransactionManager(dataSource);
+    this.jdbcRepository =
+        new JDBCRepository(new DelegatingDataSource(dataSource, transactionManager), context);
   }
 
   @Override

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/connection/ConnectionProvider.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/connection/ConnectionProvider.java
@@ -1,0 +1,10 @@
+package com.bobocode.bibernate.transaction.connection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface ConnectionProvider {
+
+  Connection get() throws SQLException;
+}

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/connection/DelegatingConnection.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/connection/DelegatingConnection.java
@@ -1,0 +1,49 @@
+package com.bobocode.bibernate.transaction.connection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+
+@RequiredArgsConstructor
+public class DelegatingConnection implements Connection {
+
+  @Delegate(excludes = Exclude.class)
+  @Getter
+  private final Connection delegate;
+
+  @Override
+  public void setAutoCommit(boolean autoCommit) throws SQLException {
+    if (autoCommit) {
+      throw new UnsupportedOperationException("Autocommit cannot be enabled");
+    }
+
+    delegate.setAutoCommit(false);
+  }
+
+  @Override
+  public void commit() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void rollback() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close() {
+    // NOOP
+  }
+
+  private interface Exclude {
+    void setAutoCommit(boolean autoCommit);
+
+    void commit();
+
+    void rollback();
+
+    void close();
+  }
+}

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/ds/DelegatingDataSource.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/ds/DelegatingDataSource.java
@@ -1,0 +1,26 @@
+package com.bobocode.bibernate.transaction.ds;
+
+import com.bobocode.bibernate.transaction.connection.ConnectionProvider;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+
+@RequiredArgsConstructor
+public class DelegatingDataSource implements DataSource {
+
+  @Delegate(excludes = Exclude.class)
+  private final DataSource delegate;
+
+  private final ConnectionProvider connectionProvider;
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    return connectionProvider.get();
+  }
+
+  private interface Exclude {
+    void getConnection();
+  }
+}

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/function/ThrowingCallable.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/function/ThrowingCallable.java
@@ -1,0 +1,7 @@
+package com.bobocode.bibernate.transaction.function;
+
+@FunctionalInterface
+public interface ThrowingCallable<T> {
+
+  T call() throws Exception;
+}

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/function/ThrowingRunnable.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/function/ThrowingRunnable.java
@@ -1,0 +1,7 @@
+package com.bobocode.bibernate.transaction.function;
+
+@FunctionalInterface
+public interface ThrowingRunnable {
+
+  void run() throws Exception;
+}

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/manager/ThreadLocalTransactionManager.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/manager/ThreadLocalTransactionManager.java
@@ -1,0 +1,134 @@
+package com.bobocode.bibernate.transaction.manager;
+
+import com.bobocode.bibernate.exception.TransactionManagerException;
+import com.bobocode.bibernate.transaction.connection.ConnectionProvider;
+import com.bobocode.bibernate.transaction.connection.DelegatingConnection;
+import com.bobocode.bibernate.transaction.function.ThrowingCallable;
+import com.bobocode.bibernate.transaction.function.ThrowingRunnable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Optional;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ThreadLocalTransactionManager implements TransactionManager, ConnectionProvider {
+
+  private static final DelegatingConnection TRANSACTION_MARKER = new DelegatingConnection(null);
+  private final ThreadLocal<DelegatingConnection> connections = new ThreadLocal<>();
+  private final DataSource rawDataSource;
+
+  @Setter private Runnable afterRollbackCallback;
+
+  @Override
+  public DelegatingConnection get() throws SQLException {
+    DelegatingConnection delegatingConnection = connections.get();
+    checkConnectionActive(delegatingConnection);
+
+    if (delegatingConnection == TRANSACTION_MARKER) {
+      Connection physicalConnection = rawDataSource.getConnection();
+      physicalConnection.setAutoCommit(false);
+      delegatingConnection = new DelegatingConnection(physicalConnection);
+
+      connections.set(delegatingConnection);
+      log.debug("Obtained a new DB connection");
+    }
+
+    return delegatingConnection;
+  }
+
+  @Override
+  public <T> T execInTransactionReturningResult(ThrowingCallable<T> throwingCallable) {
+    begin();
+    try {
+      T result = throwingCallable.call();
+      commit();
+      return result;
+    } catch (Exception e) {
+      rollback();
+      throw new TransactionManagerException(e);
+    }
+  }
+
+  public void execInTransaction(ThrowingRunnable throwingRunnable) {
+    execInTransactionReturningResult(
+        () -> {
+          throwingRunnable.run();
+          return null;
+        });
+  }
+
+  @Override
+  public void begin() {
+    verifyNoOngoingTransaction();
+
+    // setting a special marker to indicate that transaction has been started
+    connections.set(TRANSACTION_MARKER);
+    log.debug("Transaction has started");
+  }
+
+  @Override
+  public void commit() {
+    getRawConnection()
+        .ifPresent(
+            rawConnection -> {
+              try {
+                rawConnection.commit();
+                rawConnection.close();
+                log.debug("Transaction has been successfully committed");
+              } catch (SQLException ex) {
+                throw new TransactionManagerException("Exception during transaction commit", ex);
+              }
+            });
+  }
+
+  @Override
+  public void rollback() {
+    getRawConnection()
+        .ifPresent(
+            rawConnection -> {
+              try {
+                rawConnection.rollback();
+                rawConnection.close();
+                log.debug("Transaction has been successfully rolled back");
+              } catch (SQLException ex) {
+                throw new TransactionManagerException("Exception during transaction rollback", ex);
+              } finally {
+                if (afterRollbackCallback != null) {
+                  afterRollbackCallback.run();
+                }
+              }
+            });
+  }
+
+  private Optional<Connection> getRawConnection() {
+    DelegatingConnection delegatingConnection = connections.get();
+    checkConnectionActive(delegatingConnection);
+
+    connections.remove();
+
+    // if transaction is still marked as started but hasn't obtained a physical connection to DB,
+    // thus nothing to commit/rollback yet
+    if (delegatingConnection == TRANSACTION_MARKER) {
+      return Optional.empty();
+    }
+
+    //  otherwise return the obtained physical DB connection
+    return Optional.of(delegatingConnection.getDelegate());
+  }
+
+  private void checkConnectionActive(DelegatingConnection connection) {
+    if (connection == null) {
+      throw new IllegalStateException("Transaction is not active.");
+    }
+  }
+
+  private void verifyNoOngoingTransaction() {
+    if (connections.get() != null) {
+      throw new IllegalStateException("Transaction is already in progress.");
+    }
+  }
+}

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/manager/TransactionManager.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/transaction/manager/TransactionManager.java
@@ -1,0 +1,19 @@
+package com.bobocode.bibernate.transaction.manager;
+
+import com.bobocode.bibernate.transaction.function.ThrowingCallable;
+import com.bobocode.bibernate.transaction.function.ThrowingRunnable;
+
+public interface TransactionManager {
+
+  <T> T execInTransactionReturningResult(ThrowingCallable<T> throwingCallable);
+
+  void execInTransaction(ThrowingRunnable throwingRunnable);
+
+  void setAfterRollbackCallback(Runnable runnable);
+
+  void begin();
+
+  void commit();
+
+  void rollback();
+}

--- a/bibernate-orm/src/main/java/com/bobocode/bibernate/util/EntityUtils.java
+++ b/bibernate-orm/src/main/java/com/bobocode/bibernate/util/EntityUtils.java
@@ -74,7 +74,7 @@ public final class EntityUtils {
         .filter(f -> f.isAnnotationPresent(JoinColumn.class))
         .filter(f -> f.getType().equals(referencedEntityType))
         .findFirst()
-        .orElseThrow();
+        .orElseThrow(() -> new NoSuchFieldException("No field annotated @JoinColumn is found"));
   }
 
   public static Stream<Field> findAllSimpleFields(Class<?> entityType) {

--- a/bibernate-orm/src/test/java/com/bobocode/bibernate/entity/eager/EagerTweet.java
+++ b/bibernate-orm/src/test/java/com/bobocode/bibernate/entity/eager/EagerTweet.java
@@ -1,0 +1,31 @@
+package com.bobocode.bibernate.entity.eager;
+
+import com.bobocode.bibernate.annotation.Column;
+import com.bobocode.bibernate.annotation.Entity;
+import com.bobocode.bibernate.annotation.Id;
+import com.bobocode.bibernate.annotation.JoinColumn;
+import com.bobocode.bibernate.annotation.ManyToOne;
+import com.bobocode.bibernate.annotation.Table;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(name = "tweets")
+@Getter
+@Setter
+@ToString(exclude = "user")
+public class EagerTweet {
+
+  @Id private Long id;
+
+  @Column(name = "tweet_text")
+  private String tweetText;
+  //
+  //  @Column(name = "created_at")
+  //  private LocalDate createdAt;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private EagerUser user;
+}

--- a/bibernate-orm/src/test/java/com/bobocode/bibernate/entity/eager/EagerUser.java
+++ b/bibernate-orm/src/test/java/com/bobocode/bibernate/entity/eager/EagerUser.java
@@ -1,4 +1,4 @@
-package com.bobocode.bibernate.entity;
+package com.bobocode.bibernate.entity.eager;
 
 import com.bobocode.bibernate.annotation.Entity;
 import com.bobocode.bibernate.annotation.Id;
@@ -24,5 +24,5 @@ public class EagerUser {
   private String handle;
 
   @OneToMany(fetch = FetchType.EAGER)
-  private List<Tweet> tweets;
+  private List<EagerTweet> tweets;
 }

--- a/bibernate-orm/src/test/java/com/bobocode/bibernate/entity/lazy/LazyTweet.java
+++ b/bibernate-orm/src/test/java/com/bobocode/bibernate/entity/lazy/LazyTweet.java
@@ -1,4 +1,4 @@
-package com.bobocode.bibernate.entity;
+package com.bobocode.bibernate.entity.lazy;
 
 import com.bobocode.bibernate.annotation.Column;
 import com.bobocode.bibernate.annotation.Entity;
@@ -15,7 +15,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString(exclude = "user")
-public class Tweet {
+public class LazyTweet {
 
   @Id private Long id;
 
@@ -27,5 +27,5 @@ public class Tweet {
 
   @ManyToOne
   @JoinColumn(name = "user_id")
-  private EagerUser user;
+  private LazyUser user;
 }

--- a/bibernate-orm/src/test/java/com/bobocode/bibernate/entity/lazy/LazyUser.java
+++ b/bibernate-orm/src/test/java/com/bobocode/bibernate/entity/lazy/LazyUser.java
@@ -1,4 +1,4 @@
-package com.bobocode.bibernate.entity;
+package com.bobocode.bibernate.entity.lazy;
 
 import com.bobocode.bibernate.annotation.Entity;
 import com.bobocode.bibernate.annotation.Id;
@@ -24,5 +24,5 @@ public class LazyUser {
   private String handle;
 
   @OneToMany(fetch = FetchType.LAZY)
-  private List<Tweet> tweets;
+  private List<LazyTweet> tweets;
 }

--- a/bibernate-orm/src/test/java/com/bobocode/bibernate/session/impl/JDBCRepositoryTest.java
+++ b/bibernate-orm/src/test/java/com/bobocode/bibernate/session/impl/JDBCRepositoryTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import com.bobocode.bibernate.context.PersistenceContext;
-import com.bobocode.bibernate.entity.EagerUser;
+import com.bobocode.bibernate.entity.eager.EagerUser;
 import java.util.List;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;

--- a/bibernate-orm/src/test/java/com/bobocode/bibernate/transaction/manager/ThreadLocalTransactionManagerTest.java
+++ b/bibernate-orm/src/test/java/com/bobocode/bibernate/transaction/manager/ThreadLocalTransactionManagerTest.java
@@ -1,0 +1,112 @@
+package com.bobocode.bibernate.transaction.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.bobocode.bibernate.session.Session;
+import com.bobocode.bibernate.session.impl.SimpleSession;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.sql.DataSource;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ThreadLocalTransactionManagerTest {
+
+  ThreadLocalTransactionManager txManager;
+  Session session;
+
+  @SneakyThrows
+  @BeforeEach
+  void setUp() {
+    var mockedDataSource = mock(DataSource.class);
+    var mockedConnection = mock(Connection.class);
+    when(mockedDataSource.getConnection()).thenReturn(mockedConnection);
+
+    session = new SimpleSession(mockedDataSource);
+    txManager = new ThreadLocalTransactionManager(mockedDataSource);
+  }
+
+  @SneakyThrows
+  @Test
+  void
+      get_givenConnectionRequestedMultipleTimeWithinStartedTransaction_shouldReturnSameConnection() {
+    txManager.begin();
+
+    var connection1 = txManager.get();
+    var connection2 = txManager.get();
+
+    assertThat(connection1).isSameAs(connection2);
+  }
+
+  @Test
+  void begin_givenTransactionIsStartedAndNotClosed_shouldFailToBeginTransactionAgain() {
+    txManager.begin();
+
+    assertThatThrownBy(() -> txManager.begin())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Transaction is already in progress.");
+  }
+
+  @Test
+  void begin_givenPreviousTransactionIsCompleted_shouldAllowToStartAnotherTransaction() {
+    txManager.begin();
+    txManager.commit();
+
+    txManager.begin();
+    txManager.rollback();
+
+    txManager.begin();
+    txManager.commit();
+  }
+
+  @Test
+  void begin_givenMultipleThreads_shouldBeAbleToBeginMultipleTransactionsSimultaneously() {
+    for (int i = 0; i < 10; i++) {
+      CompletableFuture.runAsync(() -> txManager.begin());
+    }
+  }
+
+  @Test
+  void commit_givenTransactionIsAlreadyCommitted_shouldFailToRollback() {
+    txManager.begin();
+    txManager.commit();
+
+    assertThatThrownBy(() -> txManager.rollback())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Transaction is not active.");
+  }
+
+  @Test
+  void rollback_givenTransactionIsAlreadyRollBacked_shouldFailToCommit() {
+    txManager.begin();
+    txManager.rollback();
+
+    assertThatThrownBy(() -> txManager.commit())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Transaction is not active.");
+  }
+
+  @Test
+  void afterRollbackCallback_givenTransactionIsAlreadyRollBacked_shouldFailToCommit() {
+    List<String> result = new ArrayList<>();
+    txManager.setAfterRollbackCallback(() -> result.add("Executed after rollback"));
+
+    txManager.begin();
+    try {
+      // to mimic some done work that created a connection to DB
+      txManager.get();
+
+      throw new RuntimeException("Transaction has failed");
+    } catch (Exception ignored) {
+      txManager.rollback();
+    }
+
+    assertThat(result).hasSize(1);
+  }
+}


### PR DESCRIPTION
# Why:
ORM should provide the following API for transaction management: 

-  begin
- commit
- rollback

# How:
Implemented TransactionManager and added it to Session.

# Testing:
TODO
- [x] add tests for TransactionManager

#  Usage example:

with handly `execInTransactionReturningResult` method
``` java
   var txManager = session.getTransactionManager();

    EagerUser user =
        txManager.execInTransactionReturningResult(() -> session.find(EagerUser.class, 2L));
```

or a more explicit and verbose version:

``` java
    var txManager = session.getTransactionManager();

    txManager.begin();

    try {
      EagerUser user = session.find(EagerUser.class, 2L);
      txManager.commit();
      
      return user;
    } catch (Exception e) {
      txManager.rollback();
    }
```
